### PR TITLE
fix: Fixed flaky test testObjectInspectorUtils

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -563,6 +564,7 @@ public final class ObjectInspectorUtils {
         af.add(f[i]);
       }
     }
+    af.sort(Comparator.comparing(Field::getName, String.CASE_INSENSITIVE_ORDER));
     Field[] r = new Field[af.size()];
     for (int i = 0; i < af.size(); ++i) {
       r[i] = af.get(i);

--- a/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/objectinspector/TestObjectInspectorUtils.java
@@ -99,10 +99,10 @@ public class TestObjectInspectorUtils {
 
       assertEquals(1, soi.getStructFieldData(c, fields.get(0)));
       assertEquals("test", soi.getStructFieldData(c, fields.get(1)));
-      assertEquals(c2, soi.getStructFieldData(c, fields.get(2)));
-      assertEquals(c3, soi.getStructFieldData(c, fields.get(3)));
+      assertEquals(c2, soi.getStructFieldData(c, fields.get(3)));
+      assertEquals(c3, soi.getStructFieldData(c, fields.get(5)));
       assertEquals(c4, soi.getStructFieldData(c, fields.get(4)));
-      assertNull(soi.getStructFieldData(c, fields.get(5)));
+      assertNull(soi.getStructFieldData(c, fields.get(6)));
       ArrayList<Object> cfields = new ArrayList<Object>();
       for (int i = 0; i < 10; i++) {
         cfields.add(soi.getStructFieldData(c, fields.get(i)));
@@ -117,11 +117,11 @@ public class TestObjectInspectorUtils {
       assertEquals(
           ObjectInspectorFactory
           .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector),
-          fields.get(2).getFieldObjectInspector());
+          fields.get(3).getFieldObjectInspector());
       assertEquals(
           ObjectInspectorFactory
               .getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
-          fields.get(3).getFieldObjectInspector());
+          fields.get(5).getFieldObjectInspector());
       assertEquals(ObjectInspectorUtils
           .getStandardObjectInspector(ObjectInspectorFactory
           .getStandardListObjectInspector(ObjectInspectorFactory
@@ -131,7 +131,7 @@ public class TestObjectInspectorUtils {
       assertEquals(ObjectInspectorFactory.getStandardMapObjectInspector(
           PrimitiveObjectInspectorFactory.javaStringObjectInspector,
           PrimitiveObjectInspectorFactory.javaStringObjectInspector), fields
-          .get(5).getFieldObjectInspector());
+          .get(6).getFieldObjectInspector());
     } catch (Throwable e) {
       e.printStackTrace();
       throw e;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What is the purpose of this PR
- The PR fixes flakiness resulting from the test ```org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils.testObjectInspectorUtils```.
- The test may fail or pass non-deterministically without changes made to the source code.

### Why the test fails
- ```getDeclaredNonStaticFields()``` function returns the non-static fields of a given class. The returned fields are later tested in the test.
- Taking a look into the function, we see this line:
    ```java
    Field[] f = c.getDeclaredFields();
    ```
    ```getDeclaredFields()``` returns an array of Field objects reflecting all the fields declared by the class or interface represented by this Class object. The elements in the returned array are not sorted and are not in any particular order. 
- The static fields are removed, and added to ```ArrayList<Field>``` named ```af```:
    ```java
    ArrayList<Field> af = new ArrayList<Field>();
    for (int i = 0; i < f.length; ++i) {
      if (!Modifier.isStatic(f[i].getModifiers())) {
        af.add(f[i]);
      }
    }
    ```
- This randomness seeps into the ```Field``` array ```r```, which can fail the test when run with ```NonDex``` plugin:
    ```java
    Field[] r = new Field[af.size()];
    for (int i = 0; i < af.size(); ++i) {
      r[i] = af.get(i);
    }
    return r;
    ```

### How to reproduce the test failure
- Run the test with ```NonDex``` plugin. The command to do so is as follows:
    ```bash
    mvn -pl serde edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils#testObjectInspectorUtils
    ````
- Increase number of runs with ```-DnondexRuns=10``` (or any other number).

### Expected results
- Test should pass with ```NonDex``` plugin, consistent with increase in runs.

### Actual results
- During testing with the ```NonDex``` plugin, the following error was encountered:
    ```bash
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  02:20 min
    [INFO] Finished at: 2024-02-22T11:59:21+05:30
    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal edu.illinois:nondex-maven-plugin:2.1.1:nondex (default-cli) on project hive-serde: Unable to execute mojo: There are test failures.
    [ERROR] 
    [ERROR] Please refer to /home/aman/hive/serde/.nondex/j53cPtzXejTT0Ep76VMZHxpjk2HeEPPepdDsO9UB2M= for the individual test results.
    [ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
    [ERROR] -> [Help 1]
    [ERROR] 
    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR] 
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
    ```
    This indicates that the test is indeed flaky.

### Description of fix
- To fix this flaky behavior, we sort the ```ArrayList<Field> af``` ignoring the case, as follows:
    ```java
    af.sort(Comparator.comparing(Field::getName, String.CASE_INSENSITIVE_ORDER));
    ```
    This ensures deterministic behavior of the test, addressing the flakiness issue.
- Sorting while ignoring case sensitivity ensures consistency with this assertion in ```testObjectInspectorUtils()``` method of file ```TestObjectInspectorUtils.java```:
    ```java
    assertEquals(fields.get(0), soi.getStructFieldRef("aint"));
    ```
- We would also need to change certain indices ```fields.get()``` method for assertions to pass, as we are not sorting the array to do away with randomness. For example:
    ```java
    assertEquals(c2, soi.getStructFieldData(c, fields.get(3)));
    ```
<!--
### What changes were proposed in this pull request?
-->

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

<!--
### Why are the changes needed?
-->
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

### Is the change a dependency upgrade?
No.
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->


### How was this patch tested?
- The patch was test using ```NonDex``` plugin:
    ```bash
    mvn -pl serde edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.hadoop.hive.serde2.objectinspector.TestObjectInspectorUtils#testObjectInspectorUtils -Drat.skip -DnondexRuns=100
    ```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
